### PR TITLE
devices.json: Drop official support for Samsung Galaxy Tab A7

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -40,7 +40,7 @@
       "vendor": "Samsung",
       "model": "Galaxy Tab A7",
       "maintainer_name": "CuriousNom",
-      "active": true
+      "active": false
     },
     {
       "codename": "beryllium",


### PR DESCRIPTION
- No longer officially maintained

Change-Id: I2435c54f8283337abb8a721bcfb4331af09e8069