### PR TITLE
devices.json: Drop official support for POCO F5 Pro

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -145,7 +145,7 @@
       "vendor": "Xiaomi",
       "model": "POCO F5 Pro",
       "maintainer_name": "Lowxorx",
-      "active": true
+      "active": false
     },
     {
       "codename": "Pong",


### PR DESCRIPTION
- No longer officially maintained

Change-Id: I0026c1479f206b072c54c162312a001d2c5805b8